### PR TITLE
5.6/pseudovariables — include icon

### DIFF
--- a/docs/cookbooks/5.6.x/pseudovariables.md
+++ b/docs/cookbooks/5.6.x/pseudovariables.md
@@ -2,7 +2,7 @@
 
 Version: Kamailio SIP Server v5.6.x (stable)
 
-<img src="pseudovariables.png" class="align-right" width="200" />
+![pseudovariables.png](pseudovariables.png)
 
 ## Introduction
 


### PR DESCRIPTION
https://www.kamailio.org/wikidocs/cookbooks/devel/pseudovariables/ includes at the top an image.

https://www.kamailio.org/wikidocs/cookbooks/5.6.x/pseudovariables/ does include a placeholeder for a missing image.

This aligns the code of docs/cookbooks/5.6.x/pseudovariables.md and docs/cookbooks/devel/pseudovariables.md .