### PR TITLE
Clarify default value for tls_disable is yes

### DIFF
--- a/docs/cookbooks/5.6.x/core.md
+++ b/docs/cookbooks/5.6.x/core.md
@@ -1128,7 +1128,7 @@ Example of usage:
 **Alias name: tls_disable**
 
 Global parameter to disable TLS support in the SIP server. Default value
-is 'no'.
+is 'yes'.
 
 Note: Make sure to load the "tls" module to get tls functionality.
 

--- a/docs/cookbooks/devel/core.md
+++ b/docs/cookbooks/devel/core.md
@@ -1362,7 +1362,7 @@ Example of usage:
 **Alias name: tls_disable**
 
 Global parameter to disable TLS support in the SIP server. Default value
-is 'no'.
+is 'yes'.
 
 Note: Make sure to load the "tls" module to get tls functionality.
 


### PR DESCRIPTION
I do not know what the default value for versions below 5.6 is.