### PR TITLE
Correct upper limit for max_branches - Fix #36

### DIFF
--- a/docs/cookbooks/4.3.x/core.md
+++ b/docs/cookbooks/4.3.x/core.md
@@ -1033,7 +1033,7 @@ impact on the size of destination set created in core (e.g., via
 append_branch()) as well as the serial and parallel forking done via tm
 module. It replaces the old defined constant MAX_BRANCHES.
 
-The value has to be at least 1 and the upper limit is 31.
+The value has to be at least 1 and the upper limit is 30.
 
 Default value: 12
 

--- a/docs/cookbooks/4.4.x/core.md
+++ b/docs/cookbooks/4.4.x/core.md
@@ -1257,7 +1257,7 @@ impact on the size of destination set created in core (e.g., via
 append_branch()) as well as the serial and parallel forking done via tm
 module. It replaces the old defined constant MAX_BRANCHES.
 
-The value has to be at least 1 and the upper limit is 31.
+The value has to be at least 1 and the upper limit is 30.
 
 Default value: 12
 

--- a/docs/cookbooks/5.0.x/core.md
+++ b/docs/cookbooks/5.0.x/core.md
@@ -1292,7 +1292,7 @@ impact on the size of destination set created in core (e.g., via
 append_branch()) as well as the serial and parallel forking done via tm
 module. It replaces the old defined constant MAX_BRANCHES.
 
-The value has to be at least 1 and the upper limit is 31.
+The value has to be at least 1 and the upper limit is 30.
 
 Default value: 12
 

--- a/docs/cookbooks/5.1.x/core.md
+++ b/docs/cookbooks/5.1.x/core.md
@@ -1329,7 +1329,7 @@ impact on the size of destination set created in core (e.g., via
 append_branch()) as well as the serial and parallel forking done via tm
 module. It replaces the old defined constant MAX_BRANCHES.
 
-The value has to be at least 1 and the upper limit is 31.
+The value has to be at least 1 and the upper limit is 30.
 
 Default value: 12
 

--- a/docs/cookbooks/5.2.x/core.md
+++ b/docs/cookbooks/5.2.x/core.md
@@ -1401,7 +1401,7 @@ impact on the size of destination set created in core (e.g., via
 append_branch()) as well as the serial and parallel forking done via tm
 module. It replaces the old defined constant MAX_BRANCHES.
 
-The value has to be at least 1 and the upper limit is 31.
+The value has to be at least 1 and the upper limit is 30.
 
 Default value: 12
 

--- a/docs/cookbooks/5.3.x/core.md
+++ b/docs/cookbooks/5.3.x/core.md
@@ -1449,7 +1449,7 @@ impact on the size of destination set created in core (e.g., via
 append_branch()) as well as the serial and parallel forking done via tm
 module. It replaces the old defined constant MAX_BRANCHES.
 
-The value has to be at least 1 and the upper limit is 31.
+The value has to be at least 1 and the upper limit is 30.
 
 Default value: 12
 

--- a/docs/cookbooks/5.4.x/core.md
+++ b/docs/cookbooks/5.4.x/core.md
@@ -1497,7 +1497,7 @@ impact on the size of destination set created in core (e.g., via
 append_branch()) as well as the serial and parallel forking done via tm
 module. It replaces the old defined constant MAX_BRANCHES.
 
-The value has to be at least 1 and the upper limit is 31.
+The value has to be at least 1 and the upper limit is 30.
 
 Default value: 12
 

--- a/docs/cookbooks/5.5.x/core.md
+++ b/docs/cookbooks/5.5.x/core.md
@@ -1625,7 +1625,7 @@ impact on the size of destination set created in core (e.g., via
 append_branch()) as well as the serial and parallel forking done via tm
 module. It replaces the old defined constant MAX_BRANCHES.
 
-The value has to be at least 1 and the upper limit is 31.
+The value has to be at least 1 and the upper limit is 30.
 
 Default value: 12
 

--- a/docs/cookbooks/5.6.x/core.md
+++ b/docs/cookbooks/5.6.x/core.md
@@ -1694,7 +1694,7 @@ impact on the size of destination set created in core (e.g., via
 append_branch()) as well as the serial and parallel forking done via tm
 module. It replaces the old defined constant MAX_BRANCHES.
 
-The value has to be at least 1 and the upper limit is 31.
+The value has to be at least 1 and the upper limit is 30.
 
 Default value: 12
 

--- a/docs/cookbooks/devel/core.md
+++ b/docs/cookbooks/devel/core.md
@@ -1969,7 +1969,7 @@ impact on the size of destination set created in core (e.g., via
 append_branch()) as well as the serial and parallel forking done via tm
 module. It replaces the old defined constant MAX_BRANCHES.
 
-The value has to be at least 1 and the upper limit is 31.
+The value has to be at least 1 and the upper limit is 30.
 
 Default value: 12
 


### PR DESCRIPTION
Fix #36 - Incorrect upper limit value for `max_branches`

Changed the following line in all `core.md` files from:
```
The value has to be at least 1 and the upper limit is 31.
```
To:
```
The value has to be at least 1 and the upper limit is 30.
```
