### PR TITLE
pseudovariables: clarify $sipdump(…ip) is string, while $sipdump(…port) is number

### DIFF
--- a/docs/cookbooks/5.6.x/pseudovariables.md
+++ b/docs/cookbooks/5.6.x/pseudovariables.md
@@ -1543,10 +1543,10 @@ The name can be:
 -   buf - entire message buffer as string
 -   len - length of the message (length of above buf)
 -   af - address family
--   src_ip - source IP address
--   dst_ip - destination IP address
--   src_port - port of source address
--   dst_port - port of source address
+-   src_ip - source IP address as string
+-   dst_ip - destination IP address as string
+-   src_port - port of source address as number
+-   dst_port - port of source address as number
 -   proto - transport protocol
 
 Example:

--- a/docs/cookbooks/devel/pseudovariables.md
+++ b/docs/cookbooks/devel/pseudovariables.md
@@ -1543,10 +1543,10 @@ The name can be:
 -   buf - entire message buffer as string
 -   len - length of the message (length of above buf)
 -   af - address family
--   src_ip - source IP address
--   dst_ip - destination IP address
--   src_port - port of source address
--   dst_port - port of source address
+-   src_ip - source IP address as string
+-   dst_ip - destination IP address as string
+-   src_port - port of source address as number
+-   dst_port - port of source address as number
 -   proto - transport protocol
 
 Example:


### PR DESCRIPTION
This makes a difference in Lua, where `if KSR.pv.gete("$sipdump(dst_port)") == 5060` and `if KSR.pv.gete("$sipdump(dst_port)") == "5060"` are different things. 