### PR TITLE
5.7: upgrade links to new modules

### DIFF
--- a/docs/features/new-in-5.7.x.md
+++ b/docs/features/new-in-5.7.x.md
@@ -14,22 +14,22 @@ source code repository.*
 ### app_python3s ###
 
   * kemi python3 interpreter with statically exported KSR object
-  * https://www.kamailio.org/docs/modules/devel/modules/app_python3.html
+  * [https://www.kamailio.org/docs/modules/devel/modules/app_python3.html](https://www.kamailio.org/docs/modules/devel/modules/app_python3.html)
 
 ### app_ruby_proc ###
 
   * per-process kemi ruby API
-  * https://www.kamailio.org/docs/modules/devel/modules/app_python3.html
+  * [https://www.kamailio.org/docs/modules/devel/modules/app_ruby_proc.html](https://www.kamailio.org/docs/modules/devel/modules/app_ruby_proc.html)
 
 ### math ###
 
   * extensions for math operations
-  * https://www.kamailio.org/docs/modules/devel/modules/app_python3.html
+  * [https://www.kamailio.org/docs/modules/devel/modules/math.html](https://www.kamailio.org/docs/modules/devel/modules/math.html)
 
 ### tls_wolfssl ###
 
   * tls module using wolfssl project
-  * https://www.kamailio.org/docs/modules/devel/modules/app_python3.html
+  * [https://www.kamailio.org/docs/modules/devel/modules/tls_wolfssl.html](https://www.kamailio.org/docs/modules/devel/modules/tls_wolfssl.html)
 
 ## New in existing Modules
 

--- a/docs/install/upgrade/5.6.x-to-5.7.0.md
+++ b/docs/install/upgrade/5.6.x-to-5.7.0.md
@@ -28,8 +28,6 @@ Following tokens are used to mark the changes:
 
 ## Modules
 
-  * INF: the `tls` and `tlsa` modules do not support openssl 3.0, they have to be linked with openssl 1.1 or 1.0. Note also the availability of `tls_wolfssl` module.
-
 ### Upgraded Modules
 
   * `app_ruby` needs `app_ruby_proc` which is loaded automatically when found


### PR DESCRIPTION
- remove text about missing support in 5.7 for openssl 3.0, as the text does not apply for Kamailio 5.7.1 any more.