### PR TITLE
fix: typo for rUl and tUl pseudo-variables docs

### DIFF
--- a/docs/cookbooks/5.4.x/pseudovariables.md
+++ b/docs/cookbooks/5.4.x/pseudovariables.md
@@ -566,7 +566,7 @@ configuration file)\</fc>
 
 ### $rUl - R-URI Username Length
 
-**$rU** - the length of the username in R-URI
+**$rUl** - the length of the username in R-URI
 
 ### $rv - SIP message version
 
@@ -739,7 +739,7 @@ this variable returning the right value.
 
 ### $tUl - To URI Username Length
 
-**$tU** - the length of the username in To URI
+**$tUl** - the length of the username in To URI
 
 ### $Tb - Startup timestamp
 

--- a/docs/cookbooks/5.5.x/pseudovariables.md
+++ b/docs/cookbooks/5.5.x/pseudovariables.md
@@ -615,7 +615,7 @@ configuration file)\</fc>
 
 ### $rUl - R-URI Username Length
 
-**$rU** - the length of the username in R-URI
+**$rUl** - the length of the username in R-URI
 
 ### $rv - SIP message version
 
@@ -793,7 +793,7 @@ this variable returning the right value.
 
 ### $tUl - To URI Username Length
 
-**$tU** - the length of the username in To URI
+**$tUl** - the length of the username in To URI
 
 ### $Tb - Startup timestamp
 

--- a/docs/cookbooks/5.6.x/pseudovariables.md
+++ b/docs/cookbooks/5.6.x/pseudovariables.md
@@ -631,7 +631,7 @@ configuration file)
 
 ### $rUl - R-URI Username Length
 
-**$rU** - the length of the username in R-URI
+**$rUl** - the length of the username in R-URI
 
 ### $rv - SIP message version
 
@@ -821,7 +821,7 @@ configuration file, but its value does not change)
 
 ### $tUl - To URI Username Length
 
-**$tU** - the length of the username in To URI
+**$tUl** - the length of the username in To URI
 
 ### $Tb - Startup timestamp
 

--- a/docs/cookbooks/5.7.x/pseudovariables.md
+++ b/docs/cookbooks/5.7.x/pseudovariables.md
@@ -631,7 +631,7 @@ configuration file)
 
 ### $rUl - R-URI Username Length
 
-**$rU** - the length of the username in R-URI
+**$rUl** - the length of the username in R-URI
 
 ### $rv - SIP message version
 
@@ -821,7 +821,7 @@ configuration file, but its value does not change)
 
 ### $tUl - To URI Username Length
 
-**$tU** - the length of the username in To URI
+**$tUl** - the length of the username in To URI
 
 ### $Tb - Startup timestamp
 

--- a/docs/cookbooks/devel/pseudovariables.md
+++ b/docs/cookbooks/devel/pseudovariables.md
@@ -631,7 +631,7 @@ configuration file)
 
 ### $rUl - R-URI Username Length
 
-**$rU** - the length of the username in R-URI
+**$rUl** - the length of the username in R-URI
 
 ### $rv - SIP message version
 
@@ -821,7 +821,7 @@ configuration file, but its value does not change)
 
 ### $tUl - To URI Username Length
 
-**$tU** - the length of the username in To URI
+**$tUl** - the length of the username in To URI
 
 ### $Tb - Startup timestamp
 


### PR DESCRIPTION
- fixing typo in the documentation for pseudo-variables `$rUl` and `$tUl`