### PR TITLE
Update escaped chars `[` to correctly show on mkdocs sidebar

### DIFF
--- a/docs/cookbooks/devel/pseudovariables.md
+++ b/docs/cookbooks/devel/pseudovariables.md
@@ -3630,7 +3630,7 @@ $ltt(key) - return local generated To-tag when Kamailio sends a reply
 - $ltt(x) - $ltt(t) if the transaction was created already, otherwise
     $ltt(s)
 
-## $via0(attr) - Via\[0\] Attributes
+## $via0(attr) - Via[0] Attributes
 
 $via0(attr) - attributes of first Via header.
 

--- a/docs/cookbooks/devel/selects.md
+++ b/docs/cookbooks/devel/selects.md
@@ -92,55 +92,55 @@ add description, examples, comments, etc., please add entries above.
 
     awk -F, '{print $3 " " $1;}' selects.csv | sort | awk '{print "==== " $1 " ====\n\nExported by: " $2 "\n\n";}'
 
-### @authorization\[%s\]
+### @authorization[%s]
 
 Exported by: core
 
-### @authorization\[%s\].algorithm
+### @authorization[%s].algorithm
 
 Exported by: core
 
-### @authorization\[%s\].cnonce
+### @authorization[%s].cnonce
 
 Exported by: core
 
-### @authorization\[%s\].nc
+### @authorization[%s].nc
 
 Exported by: core
 
-### @authorization\[%s\].nonce
+### @authorization[%s].nonce
 
 Exported by: core
 
-### @authorization\[%s\].opaque
+### @authorization[%s].opaque
 
 Exported by: core
 
-### @authorization\[%s\].qop
+### @authorization[%s].qop
 
 Exported by: core
 
-### @authorization\[%s\].realm
+### @authorization[%s].realm
 
 Exported by: core
 
-### @authorization\[%s\].response
+### @authorization[%s].response
 
 Exported by: core
 
-### @authorization\[%s\].uri
+### @authorization[%s].uri
 
 Exported by: core
 
-### @authorization\[%s\].username
+### @authorization[%s].username
 
 Exported by: core
 
-### @authorization\[%s\].username.domain
+### @authorization[%s].username.domain
 
 Exported by: core
 
-### @authorization\[%s\].username.user
+### @authorization[%s].username.user
 
 Exported by: core
 
@@ -164,7 +164,7 @@ Exported by: core
 
 Exported by: core
 
-### @contact.params\[%s\]
+### @contact.params[%s]
 
 Exported by: core
 
@@ -192,7 +192,7 @@ Exported by: core
 
 Exported by: core
 
-### @contact.uri.params\[%s\]
+### @contact.uri.params[%s]
 
 Exported by: core
 
@@ -224,95 +224,95 @@ Exported by: core
 
 Exported by: core
 
-### @db.fetch\[%i\]
+### @db.fetch[%i]
 
 Exported by: db_ops
 
-### @db.fetch\[%i\].count
+### @db.fetch[%i].count
 
 Exported by: db_ops
 
-### @db.fetch\[%i\].field\[%i\]
+### @db.fetch[%i].field[%i]
 
 Exported by: db_ops
 
-### @db.fetch\[%i\].field\[%i\].nameaddr
+### @db.fetch[%i].field[%i].nameaddr
 
 Exported by: db_ops
 
-### @db.fetch\[%i\].field\[%i\].uri
+### @db.fetch[%i].field[%i].uri
 
 Exported by: db_ops
 
-### @db.fetch\[%i\].nameaddr
+### @db.fetch[%i].nameaddr
 
 Exported by: db_ops
 
-### @db.fetch\[%i\].row\[%i\]
+### @db.fetch[%i].row[%i]
 
 Exported by: db_ops
 
-### @db.fetch\[%i\].row\[%i\].field\[%i\]
+### @db.fetch[%i].row[%i].field[%i]
 
 Exported by: db_ops
 
-### @db.fetch\[%i\].row\[%i\].field\[%i\].nameaddr
+### @db.fetch[%i].row[%i].field[%i].nameaddr
 
 Exported by: db_ops
 
-### @db.fetch\[%i\].row\[%i\].field\[%i\].uri
+### @db.fetch[%i].row[%i].field[%i].uri
 
 Exported by: db_ops
 
-### @db.fetch\[%i\].row_no
+### @db.fetch[%i].row_no
 
 Exported by: db_ops
 
-### @db.fetch\[%i\].uri
+### @db.fetch[%i].uri
 
 Exported by: db_ops
 
-### @db.query\[%i\]
+### @db.query[%i]
 
 Exported by: db_ops
 
-### @db.query\[%i\].count
+### @db.query[%i].count
 
 Exported by: db_ops
 
-### @db.query\[%i\].field\[%i\]
+### @db.query[%i].field[%i]
 
 Exported by: db_ops
 
-### @db.query\[%i\].field\[%i\].nameaddr
+### @db.query[%i].field[%i].nameaddr
 
 Exported by: db_ops
 
-### @db.query\[%i\].field\[%i\].uri
+### @db.query[%i].field[%i].uri
 
 Exported by: db_ops
 
-### @db.query\[%i\].nameaddr
+### @db.query[%i].nameaddr
 
 Exported by: db_ops
 
-### @db.query\[%i\].row\[%i\]
+### @db.query[%i].row[%i]
 
 Exported by: db_ops
 
-### @db.query\[%i\].row\[%i\].field\[%i\]
+### @db.query[%i].row[%i].field[%i]
 
 Exported by: db_ops
 
-### @db.query\[%i\].row\[%i\].field\[%i\].nameaddr
+### @db.query[%i].row[%i].field[%i].nameaddr
 
 Exported by: db_ops
 
-### @db.query\[%i\].row\[%i\].field\[%i\].uri
+### @db.query[%i].row[%i].field[%i].uri
 
 Exported by: db_ops
 
-### @db.query\[%i\].uri
+### @db.query[%i].uri
 
 Exported by: db_ops
 
@@ -344,7 +344,7 @@ Exported by: core
 
 Exported by: core
 
-### @dst_uri.params\[%s\]
+### @dst_uri.params[%s]
 
 Exported by: core
 
@@ -364,31 +364,31 @@ Exported by: core
 
 Exported by: core
 
-### @eval.get\[%i\]
+### @eval.get[%i]
 
 Exported by: eval
 
-### @eval.get\[%i\].nameaddr
+### @eval.get[%i].nameaddr
 
 Exported by: eval
 
-### @eval.get\[%i\].uri
+### @eval.get[%i].uri
 
 Exported by: eval
 
-### @eval.pop\[%i\]
+### @eval.pop[%i]
 
 Exported by: eval
 
-### @eval.reg\[%s\]
+### @eval.reg[%s]
 
 Exported by: eval
 
-### @eval.reg\[%s\].nameaddr
+### @eval.reg[%s].nameaddr
 
 Exported by: eval
 
-### @eval.reg\[%s\].uri
+### @eval.reg[%s].uri
 
 Exported by: eval
 
@@ -408,7 +408,7 @@ Exported by: core
 
 Exported by: core
 
-### @f.params\[%s\]
+### @f.params[%s]
 
 Exported by: core
 
@@ -432,7 +432,7 @@ Exported by: core
 
 Exported by: core
 
-### @f.uri.params\[%s\]
+### @f.uri.params[%s]
 
 Exported by: core
 
@@ -460,7 +460,7 @@ Exported by: core
 
 Exported by: core
 
-### @from.params\[%s\]
+### @from.params[%s]
 
 Exported by: core
 
@@ -484,7 +484,7 @@ Exported by: core
 
 Exported by: core
 
-### @from.uri.params\[%s\]
+### @from.uri.params[%s]
 
 Exported by: core
 
@@ -520,15 +520,11 @@ Exported by: textops
 
 Exported by: textops
 
-### @hf_value.%s.p\[%s\]
+### @hf_value.%s.p[%s]
 
 Exported by: textops
 
-### @hf_value.%s.param\[%s\]
-
-Exported by: textops
-
-### @hf_value.%s.uri
+### @hf_value.%s.param[%s]
 
 Exported by: textops
 
@@ -536,35 +532,39 @@ Exported by: textops
 
 Exported by: textops
 
-### @hf_value.%s\[%i\]
+### @hf_value.%s.uri
 
 Exported by: textops
 
-### @hf_value.%s\[%i\].%s
+### @hf_value.%s[%i]
 
 Exported by: textops
 
-### @hf_value.%s\[%i\].name
+### @hf_value.%s[%i].%s
 
 Exported by: textops
 
-### @hf_value.%s\[%i\].nameaddr
+### @hf_value.%s[%i].name
 
 Exported by: textops
 
-### @hf_value.%s\[%i\].p\[%s\]
+### @hf_value.%s[%i].nameaddr
 
 Exported by: textops
 
-### @hf_value.%s\[%i\].param\[%s\]
+### @hf_value.%s[%i].p[%s]
 
 Exported by: textops
 
-### @hf_value.%s\[%i\].uri
+### @hf_value.%s[%i].param[%s]
 
 Exported by: textops
 
-### @hf_value.%s\[%i\].uri
+### @hf_value.%s[%i].uri
+
+Exported by: textops
+
+### @hf_value.%s[%i].uri
 
 Exported by: textops
 
@@ -584,23 +584,23 @@ Exported by: textops
 
 Exported by: textops
 
-### @hf_value2.%s\[%i\]
+### @hf_value2.%s[%i]
 
 Exported by: textops
 
-### @hf_value2.%s\[%i\].%s
+### @hf_value2.%s[%i].%s
 
 Exported by: textops
 
-### @hf_value2.%s\[%i\].%s
+### @hf_value2.%s[%i].%s
 
 Exported by: textops
 
-### @hf_value2.%s\[%i\].%s
+### @hf_value2.%s[%i].%s
 
 Exported by: textops
 
-### @hf_value_exists\[%s\].%s
+### @hf_value_exists[%s].%s
 
 Exported by: textops
 
@@ -624,7 +624,7 @@ Exported by: core
 
 Exported by: core
 
-### @m.params\[%s\]
+### @m.params[%s]
 
 Exported by: core
 
@@ -652,7 +652,7 @@ Exported by: core
 
 Exported by: core
 
-### @m.uri.params\[%s\]
+### @m.uri.params[%s]
 
 Exported by: core
 
@@ -692,7 +692,7 @@ Exported by: core
 
 Exported by: core
 
-### @msg.%s.nameaddr.params\[%s\]
+### @msg.%s.nameaddr.params[%s]
 
 Exported by: core
 
@@ -712,7 +712,7 @@ Exported by: core
 
 Exported by: core
 
-### @msg.%s.nameaddr.uri.params\[%s\]
+### @msg.%s.nameaddr.uri.params[%s]
 
 Exported by: core
 
@@ -732,75 +732,75 @@ Exported by: core
 
 Exported by: core
 
-### @msg.%s.params\[%s\]
+### @msg.%s.params[%s]
 
 Exported by: core
 
-### @msg.%s\[%i\]
+### @msg.%s[%i]
 
 Exported by: core
 
-### @msg.%s\[%i\].nameaddr
+### @msg.%s[%i].nameaddr
 
 Exported by: core
 
-### @msg.%s\[%i\].nameaddr.name
+### @msg.%s[%i].nameaddr.name
 
 Exported by: core
 
-### @msg.%s\[%i\].nameaddr.params
+### @msg.%s[%i].nameaddr.params
 
 Exported by: core
 
-### @msg.%s\[%i\].nameaddr.params\[%s\]
+### @msg.%s[%i].nameaddr.params[%s]
 
 Exported by: core
 
-### @msg.%s\[%i\].nameaddr.uri
+### @msg.%s[%i].nameaddr.uri
 
 Exported by: core
 
-### @msg.%s\[%i\].nameaddr.uri.host
+### @msg.%s[%i].nameaddr.uri.host
 
 Exported by: core
 
-### @msg.%s\[%i\].nameaddr.uri.hostport
+### @msg.%s[%i].nameaddr.uri.hostport
 
 Exported by: core
 
-### @msg.%s\[%i\].nameaddr.uri.params
+### @msg.%s[%i].nameaddr.uri.params
 
 Exported by: core
 
-### @msg.%s\[%i\].nameaddr.uri.params\[%s\]
+### @msg.%s[%i].nameaddr.uri.params[%s]
 
 Exported by: core
 
-### @msg.%s\[%i\].nameaddr.uri.port
+### @msg.%s[%i].nameaddr.uri.port
 
 Exported by: core
 
-### @msg.%s\[%i\].nameaddr.uri.pwd
+### @msg.%s[%i].nameaddr.uri.pwd
 
 Exported by: core
 
-### @msg.%s\[%i\].nameaddr.uri.type
+### @msg.%s[%i].nameaddr.uri.type
 
 Exported by: core
 
-### @msg.%s\[%i\].nameaddr.uri.user
+### @msg.%s[%i].nameaddr.uri.user
 
 Exported by: core
 
-### @msg.%s\[%i\].params\[%s\]
+### @msg.%s[%i].params[%s]
 
 Exported by: core
 
-### @nathelper.rewrite_contact\[%i\]
+### @nathelper.rewrite_contact[%i]
 
 Exported by: nathelper
 
-### @nathelper.rewrite_contact\[%i\].nameaddr
+### @nathelper.rewrite_contact[%i].nameaddr
 
 Exported by: nathelper
 
@@ -820,7 +820,7 @@ Exported by: core
 
 Exported by: core
 
-### @next_hop.params\[%s\]
+### @next_hop.params[%s]
 
 Exported by: core
 
@@ -840,55 +840,55 @@ Exported by: core
 
 Exported by: core
 
-### @proxy_authorization\[%s\]
+### @proxy_authorization[%s]
 
 Exported by: core
 
-### @proxy_authorization\[%s\].algorithm
+### @proxy_authorization[%s].algorithm
 
 Exported by: core
 
-### @proxy_authorization\[%s\].cnonce
+### @proxy_authorization[%s].cnonce
 
 Exported by: core
 
-### @proxy_authorization\[%s\].nc
+### @proxy_authorization[%s].nc
 
 Exported by: core
 
-### @proxy_authorization\[%s\].nonce
+### @proxy_authorization[%s].nonce
 
 Exported by: core
 
-### @proxy_authorization\[%s\].opaque
+### @proxy_authorization[%s].opaque
 
 Exported by: core
 
-### @proxy_authorization\[%s\].qop
+### @proxy_authorization[%s].qop
 
 Exported by: core
 
-### @proxy_authorization\[%s\].realm
+### @proxy_authorization[%s].realm
 
 Exported by: core
 
-### @proxy_authorization\[%s\].response
+### @proxy_authorization[%s].response
 
 Exported by: core
 
-### @proxy_authorization\[%s\].uri
+### @proxy_authorization[%s].uri
 
 Exported by: core
 
-### @proxy_authorization\[%s\].username
+### @proxy_authorization[%s].username
 
 Exported by: core
 
-### @proxy_authorization\[%s\].username.domain
+### @proxy_authorization[%s].username.domain
 
 Exported by: core
 
-### @proxy_authorization\[%s\].username.user
+### @proxy_authorization[%s].username.user
 
 Exported by: core
 
@@ -920,7 +920,7 @@ Exported by: core
 
 Exported by: core
 
-### @record_route.params\[%s\]
+### @record_route.params[%s]
 
 Exported by: core
 
@@ -940,7 +940,7 @@ Exported by: core
 
 Exported by: core
 
-### @record_route.uri.params\[%s\]
+### @record_route.uri.params[%s]
 
 Exported by: core
 
@@ -972,7 +972,7 @@ Exported by: rr
 
 Exported by: core
 
-### @rr.params\[%s\]
+### @rr.params[%s]
 
 Exported by: core
 
@@ -992,7 +992,7 @@ Exported by: core
 
 Exported by: core
 
-### @rr.uri.params\[%s\]
+### @rr.uri.params[%s]
 
 Exported by: core
 
@@ -1028,7 +1028,7 @@ Exported by: core
 
 Exported by: core
 
-### @ruri.params\[%s\]
+### @ruri.params[%s]
 
 Exported by: core
 
@@ -1068,7 +1068,7 @@ Exported by: core
 
 Exported by: core
 
-### @t.params\[%s\]
+### @t.params[%s]
 
 Exported by: core
 
@@ -1092,7 +1092,7 @@ Exported by: core
 
 Exported by: core
 
-### @t.uri.params\[%s\]
+### @t.uri.params[%s]
 
 Exported by: core
 
@@ -1112,7 +1112,7 @@ Exported by: core
 
 Exported by: core
 
-### @timer\[%i\].enabled
+### @timer[%i].enabled
 
 Exported by: timer
 
@@ -2772,7 +2772,7 @@ Exported by: core
 
 Exported by: core
 
-### @to.params\[%s\]
+### @to.params[%s]
 
 Exported by: core
 
@@ -2796,7 +2796,7 @@ Exported by: core
 
 Exported by: core
 
-### @to.uri.params\[%s\]
+### @to.uri.params[%s]
 
 Exported by: core
 
@@ -2868,7 +2868,7 @@ Exported by: core
 
 Exported by: core
 
-### @v.params\[%s\]
+### @v.params[%s]
 
 Exported by: core
 
@@ -2892,55 +2892,55 @@ Exported by: core
 
 Exported by: core
 
-### @v\[%i\]
+### @v[%i]
 
 Exported by: core
 
-### @v\[%i\].alias
+### @v[%i].alias
 
 Exported by: core
 
-### @v\[%i\].branch
+### @v[%i].branch
 
 Exported by: core
 
-### @v\[%i\].comment
+### @v[%i].comment
 
 Exported by: core
 
-### @v\[%i\].host
+### @v[%i].host
 
 Exported by: core
 
-### @v\[%i\].i
+### @v[%i].i
 
 Exported by: core
 
-### @v\[%i\].name
+### @v[%i].name
 
 Exported by: core
 
-### @v\[%i\].params\[%s\]
+### @v[%i].params[%s]
 
 Exported by: core
 
-### @v\[%i\].port
+### @v[%i].port
 
 Exported by: core
 
-### @v\[%i\].received
+### @v[%i].received
 
 Exported by: core
 
-### @v\[%i\].rport
+### @v[%i].rport
 
 Exported by: core
 
-### @v\[%i\].transport
+### @v[%i].transport
 
 Exported by: core
 
-### @v\[%i\].version
+### @v[%i].version
 
 Exported by: core
 
@@ -2972,7 +2972,7 @@ Exported by: core
 
 Exported by: core
 
-### @via.params\[%s\]
+### @via.params[%s]
 
 Exported by: core
 
@@ -2996,55 +2996,55 @@ Exported by: core
 
 Exported by: core
 
-### @via\[%i\]
+### @via[%i]
 
 Exported by: core
 
-### @via\[%i\].alias
+### @via[%i].alias
 
 Exported by: core
 
-### @via\[%i\].branch
+### @via[%i].branch
 
 Exported by: core
 
-### @via\[%i\].comment
+### @via[%i].comment
 
 Exported by: core
 
-### @via\[%i\].host
+### @via[%i].host
 
 Exported by: core
 
-### @via\[%i\].i
+### @via[%i].i
 
 Exported by: core
 
-### @via\[%i\].name
+### @via[%i].name
 
 Exported by: core
 
-### @via\[%i\].params\[%s\]
+### @via[%i].params[%s]
 
 Exported by: core
 
-### @via\[%i\].port
+### @via[%i].port
 
 Exported by: core
 
-### @via\[%i\].received
+### @via[%i].received
 
 Exported by: core
 
-### @via\[%i\].rport
+### @via[%i].rport
 
 Exported by: core
 
-### @via\[%i\].transport
+### @via[%i].transport
 
 Exported by: core
 
-### @via\[%i\].version
+### @via[%i].version
 
 Exported by: core
 

--- a/docs/cookbooks/devel/transformations.md
+++ b/docs/cookbooks/devel/transformations.md
@@ -264,7 +264,7 @@ $var(y) = $(var(x){s.strip,2}); # resulted value is "34"
 Return string after removing ending 'len' characters. Parameter 'len'
 can be positive integer or pseudo-variable holding a positive integer.
 
-### {s.prefixes\[,len\]}
+### {s.prefixes[,len]}
 
 Return series of comma separated prefixes of the pv. Parameter 'len' is
 optional and will limit the maximum prefix length.
@@ -274,10 +274,10 @@ Example:
 ``` c
 $var(x) = "123456";
 $(var(x){s.prefixes}) => 1,12,123,1234,12345,123456
-$(var(x){s.prefixes,4} => 1,12,123,1234
+$(var(x){s.prefixes,4}) => 1,12,123,1234
 ```
 
-### {s.prefixes.quoted\[,len\]}
+### {s.prefixes.quoted[,len]}
 
 Return series of comma separated quoted prefixes of the pv. Parameter
 'len' is optional and will limit the maximum prefix length.
@@ -286,8 +286,8 @@ Example:
 
 ``` c
 $var(x) = "123456";
-$(var(x){s.prefixes.quoted} => '1','12','123','1234','12345','123456'
-$(var(x){s.prefixes.quoted,4} => '1','12','123','1234'
+$(var(x){s.prefixes.quoted}) => '1','12','123','1234','12345','123456'
+$(var(x){s.prefixes.quoted,4}) => '1','12','123','1234'
 ```
 
 ### {s.replace,match,repl}
@@ -396,7 +396,7 @@ $var(alice) = $(var(x){s.unquote});
 
 ### {s.unbracket}
 
-Return the value without surrounding (), \[\], {} or \<\>.
+Return the value without surrounding (), [], {} or <>.
 
 ``` c
 $var(x) = "<sip:alice@test.sip>";
@@ -623,7 +623,7 @@ is a delimiter between serialized SIP header/URI bodies. The workaround
 is to use the subst transformation to replace the comma with another
 character that is used then as separator.
 
-### {param.value,name\[, delimiter\]}
+### {param.value,name[, delimiter]}
 
 Return the value of parameter 'name'
 
@@ -637,7 +637,7 @@ Example:
 parameter delimiter. For example, when parsing HTTP URL query strings
 use '&'.
 
-### {param.in,name\[,delimiter\]}
+### {param.in,name[,delimiter]}
 
 Return 1 if the parameter 'name' is found in parameters list, 0 if not
 found.
@@ -652,7 +652,7 @@ Example:
 parameter delimiter. For example, when parsing HTTP URL query strings
 use '&'.
 
-### {param.valueat,index\[, delimiter\]}
+### {param.valueat,index[, delimiter]}
 
 Return the value of parameter at position given by 'index' (0-based
 index)
@@ -667,7 +667,7 @@ Example:
 parameter delimiter. For example, when parsing HTTP URL query strings
 use '&'.
 
-### {param.name,index\[, delimiter\]}
+### {param.name,index[, delimiter]}
 
 Return the name of parameter at position 'index'.
 
@@ -679,7 +679,7 @@ Example:
 parameter delimiter. For example, when parsing HTTP URL query strings
 use '&'.
 
-### {param.count\[, delimiter\]}
+### {param.count[, delimiter]}
 
 Return the number of parameters in the list.
 
@@ -694,7 +694,7 @@ use '&'.
 ## Name-address Transformations
 
 The name of the transformation starts with 'nameaddr.'. The PV value is
-considered to be a string like '\[display_name\] uri'. The
+considered to be a string like '[display_name] uri'. The
 transformations returns the value for a specific field.
 
 Available transformations in this class:


### PR DESCRIPTION
This should fix a display issue on the wiki pages.

On the sidebard navigation of cookbooks for psuedovariables, selects and transformations pages, there was a display issue of char `[` and `[` due to escaping and making them appear as `91`. 

See screenshot below.
<img width="1920" height="1152" alt="Screenshot 2025-08-05 143543" src="https://github.com/user-attachments/assets/d8fd5906-280c-4696-a784-4cb52318a5f7" />


Even though [markdown guide](https://www.markdownguide.org/basic-syntax/#escaping-characters) suggest to do so, it can't be rendered for some reason.

Removing the escape, it just works as well and the links are now displayed as they should.
<img width="1920" height="1152" alt="Screenshot 2025-08-05 143438" src="https://github.com/user-attachments/assets/1bac9b61-2cbd-43a3-9396-b9188137bb2e" />


- No need for escaping [] in markdown apparently
- without escaping they visualize correctly both on body of page and sidebar navigation panel
- Update some missing ) in examples