### PR TITLE
/cookbooks/(devel|6.0.x)/pseudovariables.md: Add `$?`

### DIFF
--- a/docs/cookbooks/6.0.x/pseudovariables.md
+++ b/docs/cookbooks/6.0.x/pseudovariables.md
@@ -602,6 +602,8 @@ RFC 3325)
 
 **$retcode** - same as **$rc**
 
+**$?** - same as **$rc**
+
 Note that the value of $rc is overwritten by each new function call.
 
 Example of use:

--- a/docs/cookbooks/devel/pseudovariables.md
+++ b/docs/cookbooks/devel/pseudovariables.md
@@ -632,6 +632,8 @@ RFC 3325)
 
 **$retcode** - same as **$rc**
 
+**$?** - same as **$rc**
+
 Note that the value of $rc is overwritten by each new function call.
 
 Example of use:


### PR DESCRIPTION
Fix #75 Pseudovariable $? is not documented in pseudovariables.md