### PR TITLE
cookbooks / pseudovariables: Typo in $rcv() key scrport -> srcport

### DIFF
--- a/docs/cookbooks/5.3.x/pseudovariables.md
+++ b/docs/cookbooks/5.3.x/pseudovariables.md
@@ -1158,7 +1158,7 @@ The key can be:
 - len - lenght of received message
 - srcip - source ip
 - rcvip - local ip where it was received
-- scrport - source port
+- srcport - source port
 - rcvport - local port where it was received
 - proto - protocol as int id
 - sproto - protocol as string

--- a/docs/cookbooks/5.4.x/pseudovariables.md
+++ b/docs/cookbooks/5.4.x/pseudovariables.md
@@ -1235,7 +1235,7 @@ The key can be:
 - len - lenght of received message
 - srcip - source ip
 - rcvip - local ip where it was received
-- scrport - source port
+- srcport - source port
 - rcvport - local port where it was received
 - proto - protocol as int id
 - sproto - protocol as string

--- a/docs/cookbooks/5.5.x/pseudovariables.md
+++ b/docs/cookbooks/5.5.x/pseudovariables.md
@@ -1292,7 +1292,7 @@ The key can be:
 - len - lenght of received message
 - srcip - source ip
 - rcvip - local ip where it was received
-- scrport - source port
+- srcport - source port
 - rcvport - local port where it was received
 - proto - protocol as int id
 - sproto - protocol as string

--- a/docs/cookbooks/5.6.x/pseudovariables.md
+++ b/docs/cookbooks/5.6.x/pseudovariables.md
@@ -1390,7 +1390,7 @@ The key can be:
 - len - lenght of received message
 - srcip - source ip
 - rcvip - local ip where it was received
-- scrport - source port
+- srcport - source port
 - rcvport - local port where it was received
 - proto - protocol as int id
 - sproto - protocol as string

--- a/docs/cookbooks/5.7.x/pseudovariables.md
+++ b/docs/cookbooks/5.7.x/pseudovariables.md
@@ -1390,7 +1390,7 @@ The key can be:
 - len - lenght of received message
 - srcip - source ip
 - rcvip - local ip where it was received
-- scrport - source port
+- srcport - source port
 - rcvport - local port where it was received
 - proto - protocol as int id
 - sproto - protocol as string

--- a/docs/cookbooks/5.8.x/pseudovariables.md
+++ b/docs/cookbooks/5.8.x/pseudovariables.md
@@ -1409,7 +1409,7 @@ The key can be:
 - len - lenght of received message
 - srcip - source ip
 - rcvip - local ip where it was received
-- scrport - source port
+- srcport - source port
 - rcvport - local port where it was received
 - proto - protocol as int id
 - sproto - protocol as string

--- a/docs/cookbooks/6.0.x/pseudovariables.md
+++ b/docs/cookbooks/6.0.x/pseudovariables.md
@@ -1546,7 +1546,7 @@ The key can be:
 - len - lenght of received message
 - srcip - source ip
 - rcvip - local ip where it was received
-- scrport - source port
+- srcport - source port
 - rcvport - local port where it was received
 - proto - protocol as int id
 - sproto - protocol as string

--- a/docs/cookbooks/devel/pseudovariables.md
+++ b/docs/cookbooks/devel/pseudovariables.md
@@ -1591,7 +1591,7 @@ The key can be:
 - len - lenght of received message
 - srcip - source ip
 - rcvip - local ip where it was received
-- scrport - source port
+- srcport - source port
 - rcvport - local port where it was received
 - proto - protocol as int id
 - sproto - protocol as string


### PR DESCRIPTION
Fix small typo in pseudovariable $rcv()