### PR TITLE
Fix Kamailio-wiki #95

### DIFF
--- a/docs/cookbooks/devel/pseudovariables.md
+++ b/docs/cookbooks/devel/pseudovariables.md
@@ -3458,7 +3458,8 @@ The key can be:
 
 ### $cfg(key) - Config File Attributes
 
-Attributes related to configuration file.
+Attributes related to configuration file. It is exported by the **corex**
+module.
 
 The key can be:
 


### PR DESCRIPTION
Fix https://github.com/kamailio/kamailio-wiki/issues/95:  Module export for `$cfg()` not noted.